### PR TITLE
Avoid short beep during breath stage transitions

### DIFF
--- a/index.html
+++ b/index.html
@@ -102,18 +102,21 @@
 
             const stageTime = currentTime % stages.reduce((a, b) => a + b, 0);
             let accumulatedTime = 0;
+            let boundary = false;
             for (let i = 0; i < stages.length; i++) {
                 accumulatedTime += stages[i];
                 if (stageTime === accumulatedTime) {
                     playLongBeep();
                     currentStage = (currentStage + 1) % 4;
                     updateStageDisplay();
+                    boundary = true;
+                    break;
                 } else if (stageTime < accumulatedTime) {
                     break;
                 }
             }
 
-            if (stageTime !== 0) {
+            if (stageTime !== 0 && !boundary) {
                 playShortBeep();
             }
 


### PR DESCRIPTION
## Summary
- prevent short beep from playing alongside long beep when transitioning between stages

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ae023e51888322b4cc0972527ef661